### PR TITLE
Improve pthread flag handling and update kogyan submodule

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,9 +185,10 @@ test -z $DOXYGEN && \
 #### Library Checks ####
 AX_PTHREAD
 AX_PTHREAD_LINK_CFLAGS=""
-AS_IF(
-    [test "x${PTHREAD_CFLAGS}" = "x-pthread" || test "x${PTHREAD_CFLAGS}" = "x-pthreads"],
-    [AX_PTHREAD_LINK_CFLAGS="${PTHREAD_CFLAGS}"]
+AS_CASE(
+    [" ${PTHREAD_CFLAGS} "],
+    [*" -pthread "*], [AX_PTHREAD_LINK_CFLAGS="-pthread"],
+    [*" -pthreads "*], [AX_PTHREAD_LINK_CFLAGS="-pthreads"]
 )
 AS_IF(
     [test -n "${AX_PTHREAD_LINK_CFLAGS}"],

--- a/configure.ac
+++ b/configure.ac
@@ -184,10 +184,14 @@ test -z $DOXYGEN && \
 
 #### Library Checks ####
 AX_PTHREAD
-AX_PTHREAD_LINK_CFLAGS="${PTHREAD_CFLAGS}"
+AX_PTHREAD_LINK_CFLAGS=""
 AS_IF(
-    [${CXX} --version 2>/dev/null | grep -qi clang],
-    [test "x${PTHREAD_CFLAGS}" = "x-pthread" && AX_PTHREAD_LINK_CFLAGS=""]
+    [test "x${PTHREAD_CFLAGS}" = "x-pthread" || test "x${PTHREAD_CFLAGS}" = "x-pthreads"],
+    [AX_PTHREAD_LINK_CFLAGS="${PTHREAD_CFLAGS}"]
+)
+AS_IF(
+    [test -n "${AX_PTHREAD_LINK_CFLAGS}"],
+    [LDFLAGS="${AX_PTHREAD_LINK_CFLAGS} ${LDFLAGS}"]
 )
 LDFLAGS="${AX_PTHREAD_LINK_CFLAGS} ${LDFLAGS}"
 AC_SUBST([LIBS], "${PTHREAD_LIBS} ${LIBS}")


### PR DESCRIPTION
This pull request updates the handling of pthread compiler and linker flags in the build configuration and also updates a submodule reference. The main focus is to ensure the correct pthread flags are used for linking, improving portability and compatibility across different systems.

Build system improvements:

* Refined the logic in `configure.ac` to set `AX_PTHREAD_LINK_CFLAGS` based on the presence of `-pthread` or `-pthreads` in `PTHREAD_CFLAGS`, and to add the appropriate flag to `LDFLAGS` only when necessary. This makes the pthread linking process more robust and avoids potential issues with different compilers and platforms.

Submodule update:

* Updated the `kogyan` submodule to point to a newer commit (`4217a272a2e25d6b7e8b49643a9177a9157aca72`).