### PR TITLE
ci: upgrade Doxygen to 1.17.0 #358

### DIFF
--- a/.github/workflows/linux-clang.yml
+++ b/.github/workflows/linux-clang.yml
@@ -16,7 +16,7 @@ env:
   CONCURRENT_BUILD:        4
   CLANG_COMMAND:           clang-18
   CLANGXX_COMMAND:         clang++-18
-  DOXYGEN_VER:             1.16.1
+  DOXYGEN_VER:             1.17.0
   DOXYGEN_CACHE_REV:       0
   BOOST_VER:               1_91_0
   BOOST_VER_DOT:           1.91.0

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ How to Build and Install
 
 - [Visual Studio 2026](https://visualstudio.microsoft.com/)
 - [Boost C++ libraries 1.91.0](https://www.boost.org/)
-- [Doxygen 1.16.1](https://www.doxygen.nl/)
+- [Doxygen 1.17.0](https://www.doxygen.nl/)
 - [Graphviz](https://www.graphviz.org/)
 - [WiX toolset 7.0.0](https://wixtoolset.org/)
 - [Python 3.12](https://www.python.org/)
@@ -140,7 +140,7 @@ Doxygen will output the documents into the directory `doc`.
 - [Clang 18](https://clang.llvm.org/) or
   [GCC 14](https://gcc.gnu.org/)
 - [Boost C++ libraries 1.91.0](https://www.boost.org/)
-- [Doxygen 1.16.1](https://www.doxygen.nl/)
+- [Doxygen 1.17.0](https://www.doxygen.nl/)
 - [Graphviz](https://www.graphviz.org/)
 - [include-what-you-use](https://include-what-you-use.org/)
 - [Clang Format](https://clang.llvm.org/docs/ClangFormat.html)


### PR DESCRIPTION
Update DOXYGEN_VER from 1.16.1 to 1.17.0 in the Linux Clang GitHub Actions workflow and README.md requirements sections.

Update the Doxygen cache key to use the new version for cache invalidation.